### PR TITLE
Fix test bitmap

### DIFF
--- a/Blurhash.System.Drawing.Common.Test/ImageConversionTest.cs
+++ b/Blurhash.System.Drawing.Common.Test/ImageConversionTest.cs
@@ -18,7 +18,7 @@ namespace System.Drawing.Common.Blurhash
             for (var x = 0; x < 20; x++)
                 for (var y = 0; y < 20; y++)
                 {
-                    sourceImage.SetPixel(x, y, Color.FromArgb(rnd.Next(0, 1) * 255, rnd.Next(0, 1) * 255, rnd.Next(0, 1) * 255));
+                    sourceImage.SetPixel(x, y, Color.FromArgb(rnd.Next(0, 2) * 255, rnd.Next(0, 2) * 255, rnd.Next(0, 2) * 255));
                 }
 
             var sourceData = Encoder.ConvertBitmap(sourceImage);
@@ -52,7 +52,7 @@ namespace System.Drawing.Common.Blurhash
             for (var x = 0; x < 20; x++)
             for (var y = 0; y < 20; y++)
             {
-                sourceImage.SetPixel(x, y, Color.FromArgb(rnd.Next(0, 1) * 255, rnd.Next(0, 1) * 255, rnd.Next(0, 1) * 255));
+                sourceImage.SetPixel(x, y, Color.FromArgb(rnd.Next(0, 2) * 255, rnd.Next(0, 2) * 255, rnd.Next(0, 2) * 255));
             }
 
             var sourceData = Encoder.ConvertBitmap(sourceImage);

--- a/Blurhash.System.Drawing.Test/ImageConversionTest.cs
+++ b/Blurhash.System.Drawing.Test/ImageConversionTest.cs
@@ -17,7 +17,7 @@ namespace System.Drawing.Blurhash.DotNetFramework.Test
             for (var x = 0; x < 20; x++)
                 for (var y = 0; y < 20; y++)
                 {
-                    sourceImage.SetPixel(x, y, Color.FromArgb(rnd.Next(0, 1) * 255, rnd.Next(0, 1) * 255, rnd.Next(0, 1) * 255));
+                    sourceImage.SetPixel(x, y, Color.FromArgb(rnd.Next(0, 2) * 255, rnd.Next(0, 2) * 255, rnd.Next(0, 2) * 255));
                 }
 
             var sourceData = Encoder.ConvertBitmap(sourceImage);
@@ -51,7 +51,7 @@ namespace System.Drawing.Blurhash.DotNetFramework.Test
             for (var x = 0; x < 20; x++)
             for (var y = 0; y < 20; y++)
             {
-                sourceImage.SetPixel(x, y, Color.FromArgb(rnd.Next(0, 1) * 255, rnd.Next(0, 1) * 255, rnd.Next(0, 1) * 255));
+                sourceImage.SetPixel(x, y, Color.FromArgb(rnd.Next(0, 2) * 255, rnd.Next(0, 2) * 255, rnd.Next(0, 2) * 255));
             }
 
             var sourceData = Encoder.ConvertBitmap(sourceImage);


### PR DESCRIPTION
I guessed that TestConversion(24|32)BppRgb are trying to generate random bitmap with 0 and 255 RGB values, but Random.Next(0,1) only outputs 0 and never outputs 1. So it produces just black bitmap, these tests won't work as intended.
Random.Next(0,2) outputs 0 and 1. so it will be fixed.