### PR TITLE
fix indexOutOfRangeException in Blurhash.ImageSharp

### DIFF
--- a/Blurhash.ImageSharp/Encoder.cs
+++ b/Blurhash.ImageSharp/Encoder.cs
@@ -57,7 +57,7 @@ namespace Blurhash.ImageSharp
             {
                 var rgbValues = MemoryMarshal.AsBytes(sourceBitmap.GetPixelRowSpan(y));
 
-                var index = stride;
+                var index = 0;
 
                 for (var x = 0; x < width; x++)
                 {

--- a/Blurhash.ImageSharp/Encoder.cs
+++ b/Blurhash.ImageSharp/Encoder.cs
@@ -49,7 +49,6 @@ namespace Blurhash.ImageSharp
             var width = sourceBitmap.Width;
             var height = sourceBitmap.Height;
             var bytesPerPixel = sourceBitmap.PixelType.BitsPerPixel / 8;
-            var stride = width * 3;
 
             var result = new Pixel[width, height];
             


### PR DESCRIPTION
ConvertBitmap always fails.
I just fixed it.