### PR TITLE
Fix running tests on Linux and macOS

### DIFF
--- a/Blurhash.ImageSharp.Test/BlurhasherTests.cs
+++ b/Blurhash.ImageSharp.Test/BlurhasherTests.cs
@@ -22,7 +22,7 @@ namespace Blurhash.ImageSharp.Test
             using var resultStream = new BinaryReader(ms);
             var resultBytes = resultStream.ReadBytes((int)ms.Length);
 
-            await using var expectation = File.OpenRead(@"Resources\Expectations\BlurResult1.png");
+            await using var expectation = File.OpenRead(Path.Combine("Resources", "Expectations", "BlurResult1.png"));
             using var fileStream = new BinaryReader(expectation);
             var actualBytes = fileStream.ReadBytes((int)expectation.Length);
 
@@ -32,7 +32,7 @@ namespace Blurhash.ImageSharp.Test
         [Fact]
         public async Task EncodingTests()
         {
-            var sourceImage = await Image.LoadAsync<Rgba32>(@"Resources\Specimens\Sample.png");
+            var sourceImage = await Image.LoadAsync<Rgba32>(Path.Combine("Resources", "Specimens", "Sample.png"));
 
             var result = Blurhasher.Encode(sourceImage, 9, 9);
 

--- a/Blurhash.System.Drawing.Common.Test/Blurhash.System.Drawing.Common.Test.csproj
+++ b/Blurhash.System.Drawing.Common.Test/Blurhash.System.Drawing.Common.Test.csproj
@@ -18,6 +18,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
+        <PackageReference Include="Xunit.SkippableFact" Version="1.5.23" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Blurhash.System.Drawing.Common.Test/ImageConversionTest.cs
+++ b/Blurhash.System.Drawing.Common.Test/ImageConversionTest.cs
@@ -2,6 +2,7 @@
 using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
+using System.Runtime.Versioning;
 using System.Text;
 using FluentAssertions;
 using FluentAssertions.Execution;
@@ -10,9 +11,10 @@ using Xunit;
 // ReSharper disable once CheckNamespace Justification: Meant to extend the System.Drawing.Common-Namespace
 namespace System.Drawing.Common
 {
+    [SupportedOSPlatform("Windows")]
     public class ImageConversionTest
     {
-        [Fact]
+        [SkippableFact]
         public void TestConversion24BppRgb()
         {
             var rnd = new Random();
@@ -46,7 +48,7 @@ namespace System.Drawing.Common
             }
         }
 
-        [Fact]
+        [SkippableFact]
         public void TestConversion32BppRgb()
         {
             var rnd = new Random();
@@ -80,7 +82,7 @@ namespace System.Drawing.Common
             }
         }
 
-        [Fact]
+        [SkippableFact]
         public void TestEncoding()
         {
             var img = Image.FromFile("TestData\\input.jpg");
@@ -96,7 +98,7 @@ namespace System.Drawing.Common
             }
         }
 
-        [Fact]
+        [SkippableFact]
         public void TestDecoding()
         {
             foreach (var componentsX in Enumerable.Range(1, 9))


### PR DESCRIPTION
* BlurhasherTests requires `Path.Combine` instead of hardcoded `\` path separator.
* ImageConversionTest requires all tests to be skipped on non-Windows platforms because `System.Drawing` is only available on Windows (it throws `PlatformNotSupportedException`).